### PR TITLE
feat(django-uploads): Add warning for image sizes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,97 @@
 import pytest
+from factory.django import DjangoModelFactory
+from factory import Faker
+from uploads.models import Document
 
-from .factories import DocumentFactory
+
+class DocumentFactory(DjangoModelFactory):
+    class Meta:
+        model = Document
+
+    name = Faker("word")
+    description = Faker("text")
 
 
 @pytest.fixture
-def document():
-    return DocumentFactory()
+def document(mocker):
+    # GIVEN
+    mock_file = mocker.MagicMock()
+    mock_file.name = "document.pdf"
+    mock_file.size = 51200  # 50KB
+    mock_file.path = "/fake/path/document.pdf"
+    mock_file.url = "/media/document.pdf"
+    mock_file.read.return_value = b"fake content"
+    mock_file.file = mock_file
+
+    # WHEN
+    document = DocumentFactory(name="Test Document")
+    document.file = mock_file
+
+    # THEN
+    return document
+
+
+@pytest.fixture
+def large_image(mocker):
+    # GIVEN
+    mock_file = mocker.MagicMock()
+    mock_file.name = "large_image.jpg"
+    mock_file.size = 1048576  # 1MB
+    mock_file.path = "/fake/path/large_image.jpg"
+    mock_file.url = "/media/large_image.jpg"
+    mock_file.read.return_value = b"fake content"
+    mock_file.file = mock_file
+
+    # WHEN
+    document = DocumentFactory(name="Large Image")
+    document.file = mock_file
+
+    # THEN
+    return document
+
+
+@pytest.fixture
+def small_image(mocker):
+    # GIVEN
+    mock_file = mocker.MagicMock()
+    mock_file.name = "small_image.jpg"
+    mock_file.size = 102400  # 100KB
+    mock_file.path = "/fake/path/small_image.jpg"
+    mock_file.url = "/media/small_image.jpg"
+    mock_file.read.return_value = b"fake content"
+    mock_file.file = mock_file
+
+    # WHEN
+    document = DocumentFactory(name="Small Image")
+    document.file = mock_file
+
+    # THEN
+    return document
+
+
+@pytest.fixture
+def document_with_accent(mocker):
+    # GIVEN
+    original_path = "/fake/path/document.pdf"
+    new_path = "/fake/path/document_with_accent.pdf"
+    
+    mock_file = mocker.MagicMock()
+    mock_file.name = "document.pdf"
+    mock_file.size = 51200  # 50KB
+    mock_file.path = original_path
+    mock_file.url = "/media/document.pdf"
+    mock_file.read.return_value = b"fake content"
+    mock_file.file = mock_file
+
+    # WHEN
+    document = DocumentFactory(name="Documenté avec accent")
+    document.file = mock_file
+
+    def save(*args, **kwargs):
+        if "update_fields" in kwargs and "name" in kwargs["update_fields"]:
+            mock_file.path = new_path
+
+    document.save = save
+
+    # THEN
+    return document

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,3 +10,5 @@ INSTALLED_APPS = (
 )
 
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
+
+UPLOADS_WARNING_SIZE = 307200  # 300KB

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -6,20 +6,42 @@ pytestmark = pytest.mark.django_db
 class TestDeleteFiles:
     def test_with_existing_file(self, document, mocker):
         # GIVEN
-        mock = mocker.patch("os.remove")
+        mock_remove = mocker.patch("os.remove")
 
         # WHEN
         document.delete()
 
         # THEN
-        mock.assert_called_once_with(document.file.path)
+        mock_remove.assert_called_once_with(document.file.path)
 
     def test_with_not_existing_file(self, document, mocker):
         # GIVEN
-        mock = mocker.patch("uploads.signals.handlers.logger.info")
+        mock_logger = mocker.patch("uploads.signals.handlers.logger.info")
+        mock_remove = mocker.patch("os.remove", side_effect=FileNotFoundError)
 
         # WHEN
         document.delete()
 
         # THEN
-        mock.assert_called_once_with("The file was already deleted.")
+        mock_remove.assert_called_once_with(document.file.path)
+        mock_logger.assert_called_once_with("The file was already deleted.")
+
+    def test_delete_large_image_file(self, large_image, mocker):
+        # GIVEN
+        mock_remove = mocker.patch("os.remove")
+
+        # WHEN
+        large_image.delete()
+
+        # THEN
+        mock_remove.assert_called_once_with(large_image.file.path)
+
+    def test_delete_small_image_file(self, small_image, mocker):
+        # GIVEN
+        mock_remove = mocker.patch("os.remove")
+
+        # WHEN
+        small_image.delete()
+
+        # THEN
+        mock_remove.assert_called_once_with(small_image.file.path)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,3 +8,54 @@ pytestmark = pytest.mark.django_db
 class TestDocument:
     def test_upload_file(self, document):
         assert document.pk == Document.objects.last().pk
+
+    def test_rename_file_with_accent(self, document_with_accent):
+        # GIVEN
+        original_name = document_with_accent.name
+        original_file_path = document_with_accent.file.path
+
+        # WHEN
+        document_with_accent.name = "Nouveau nom sans accent"
+        document_with_accent.save(update_fields=['name'])
+
+        # THEN
+        assert document_with_accent.name == "Nouveau nom sans accent"
+        assert document_with_accent.file.path != original_file_path
+        assert not any(c in document_with_accent.name for c in "éèêëàâäôöûüç")
+
+    def test_file_size_warning_for_large_image(self, large_image):
+        # GIVEN
+        size_in_mb = large_image.file.size / (1024 * 1024)
+
+        # WHEN
+        file_size_display = large_image.get_file_size()
+
+        # THEN
+        assert "Mo" in file_size_display
+        assert "⚠️" in file_size_display
+        assert str(round(size_in_mb, 2)) in file_size_display
+
+    def test_file_size_no_warning_for_small_image(self, small_image):
+        # GIVEN
+        size_in_kb = small_image.file.size / 1024
+
+        # WHEN
+        file_size_display = small_image.get_file_size()
+
+        # THEN
+        assert "Ko" in file_size_display
+        assert "⚠️" not in file_size_display
+        assert str(round(size_in_kb, 2)) in file_size_display
+
+    def test_is_image_method(self, small_image, document):
+        # GIVEN
+        image_document = small_image
+        non_image_document = document
+
+        # WHEN
+        is_image_result = image_document.is_image()
+        is_not_image_result = non_image_document.is_image()
+
+        # THEN
+        assert is_image_result is True
+        assert is_not_image_result is False

--- a/uploads/admin.py
+++ b/uploads/admin.py
@@ -14,11 +14,11 @@ class DocumentAdmin(admin.ModelAdmin):
 
     def get_form(self, request, obj=None, **kwargs):
         form = super().get_form(request, obj, **kwargs)
-        if obj and obj.file.size >= settings.UPLOADS_WARNING_SIZE and self.is_image(obj):
+        if obj and obj.file.size >= settings.UPLOADS_WARNING_SIZE and obj.is_image():
             if not hasattr(request, '_document_size_warning'):
                 messages.warning(
                     request,
-                    f"Attention : Cette image fait {self.get_file_size(obj)}. Il est recommandé de ne pas dépasser {int(settings.UPLOADS_WARNING_SIZE / 1024.0)} Ko."
+                    f"Attention : Cette image fait {obj.get_file_size()}. Il est recommandé de ne pas dépasser {int(settings.UPLOADS_WARNING_SIZE / 1024.0)} Ko."
                 )
                 request._document_size_warning = True
         return form
@@ -27,24 +27,7 @@ class DocumentAdmin(admin.ModelAdmin):
         description="Taille du fichier",
     )
     def get_file_size(self, obj):
-        size = obj.file.size
-        warning = ""
-        if size >= settings.UPLOADS_WARNING_SIZE and self.is_image(obj): warning = "⚠️"
-
-        if size < 512000:
-            size = size / 1024.0
-            ext = 'Ko'
-        elif size < 4194304000:
-            size = size / 1048576.0
-            ext = 'Mo'
-        else:
-            size = size / 1073741824.0
-            ext = 'Go'
-
-        return f"{str(round(size, 2))} {ext} {warning}"
-    
-    def is_image(self, obj):
-        return obj.file.name.lower().endswith(('.png', '.jpg', '.jpeg', '.gif', '.webp'))
+        return obj.get_file_size()
 
     @admin.display(description="Lien du fichier")
     def file_absolute_url(self, obj):

--- a/uploads/admin.py
+++ b/uploads/admin.py
@@ -7,10 +7,10 @@ from .models import Document
 
 
 class DocumentAdmin(admin.ModelAdmin):
-    list_display = ("__str__", "description", "get_file_size", "file_absolute_url", "updated")
+    list_display = ("__str__", "description", "file_size", "file_absolute_url", "updated")
     readonly_fields = ("updated", "created")
     ordering = ("-updated",)
-    search_fields = ("name", "description", "get_file_size")
+    search_fields = ("name", "description")
 
     def get_form(self, request, obj=None, **kwargs):
         form = super().get_form(request, obj, **kwargs)
@@ -23,10 +23,8 @@ class DocumentAdmin(admin.ModelAdmin):
                 request._document_size_warning = True
         return form
 
-    @admin.display(
-        description="Taille du fichier",
-    )
-    def get_file_size(self, obj):
+    @admin.display(description="Taille du fichier")
+    def file_size(self, obj):
         return obj.get_file_size()
 
     @admin.display(description="Lien du fichier")

--- a/uploads/admin.py
+++ b/uploads/admin.py
@@ -1,14 +1,50 @@
 from django.conf import settings
 from django.contrib import admin
 from django.utils.html import mark_safe
+from django.contrib import messages
 
 from .models import Document
 
 
 class DocumentAdmin(admin.ModelAdmin):
-    list_display = ("__str__", "description", "file_absolute_url", "updated")
+    list_display = ("__str__", "description", "get_file_size", "file_absolute_url", "updated")
     readonly_fields = ("updated", "created")
-    search_fields = ("name", "description")
+    ordering = ("-updated",)
+    search_fields = ("name", "description", "get_file_size")
+
+    def get_form(self, request, obj=None, **kwargs):
+        form = super().get_form(request, obj, **kwargs)
+        if obj and obj.file.size >= settings.UPLOADS_WARNING_SIZE and self.is_image(obj):
+            if not hasattr(request, '_document_size_warning'):
+                messages.warning(
+                    request,
+                    f"Attention : Cette image fait {self.get_file_size(obj)}. Il est recommandé de ne pas dépasser {int(settings.UPLOADS_WARNING_SIZE / 1024.0)} Ko."
+                )
+                request._document_size_warning = True
+        return form
+
+    @admin.display(
+        description="Taille du fichier",
+    )
+    def get_file_size(self, obj):
+        size = obj.file.size
+        warning = ""
+        if size >= settings.UPLOADS_WARNING_SIZE and self.is_image(obj): warning = "⚠️"
+
+        if size < 512000:
+            size = size / 1024.0
+            ext = 'Ko'
+        elif size < 4194304000:
+            size = size / 1048576.0
+            ext = 'Mo'
+        else:
+            size = size / 1073741824.0
+            ext = 'Go'
+
+        return f"{str(round(size, 2))} {ext} {warning}"
+    
+    def is_image(self, obj):
+        return obj.file.name.lower().endswith(('.png', '.jpg', '.jpeg', '.gif', '.webp'))
 
     def file_absolute_url(self, obj):
         url = f"{settings.SITE_DOMAIN}{obj.file.url}"

--- a/uploads/admin.py
+++ b/uploads/admin.py
@@ -46,9 +46,10 @@ class DocumentAdmin(admin.ModelAdmin):
     def is_image(self, obj):
         return obj.file.name.lower().endswith(('.png', '.jpg', '.jpeg', '.gif', '.webp'))
 
+    @admin.display(description="Lien du fichier")
     def file_absolute_url(self, obj):
         url = f"{settings.SITE_DOMAIN}{obj.file.url}"
-        return mark_safe(f"<a href='{url}' target='_BLANK'>File link</a>")
+        return mark_safe(f"<a href='{url}' target='_BLANK'>{obj.file.name.split('/')[-1]}</a>")
 
 
 admin.site.register(Document, DocumentAdmin)

--- a/uploads/models.py
+++ b/uploads/models.py
@@ -1,4 +1,5 @@
 import logging
+import unicodedata
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.base import ContentFile
@@ -16,6 +17,10 @@ def upload_to(instance, filename):
 
 class RenameMixin(models.Model):
     def save(self, *args, **kwargs):
+        self.name = "".join(
+            c for c in unicodedata.normalize("NFD", self.name)
+            if unicodedata.category(c) != "Mn"
+        )
         saved_object = self.get_saved_object()
         if saved_object is not None:
             if self.name != saved_object.name:

--- a/uploads/models.py
+++ b/uploads/models.py
@@ -4,6 +4,7 @@ import unicodedata
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.base import ContentFile
 from django.db import models
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -66,3 +67,24 @@ class Document(RenameMixin, models.Model):
                 self.file_deleted = True
 
         super().save(*args, **kwargs)
+
+    def get_file_size(self):
+        size = self.file.size
+        warning = ""
+        if size >= settings.UPLOADS_WARNING_SIZE and self.is_image(): 
+            warning = "⚠️"
+
+        if size < 512000:
+            size = size / 1024.0
+            ext = 'Ko'
+        elif size < 4194304000:
+            size = size / 1048576.0
+            ext = 'Mo'
+        else:
+            size = size / 1073741824.0
+            ext = 'Go'
+
+        return f"{str(round(size, 2))} {ext} {warning}"
+
+    def is_image(self):
+        return self.file.name.lower().endswith(('.png', '.jpg', '.jpeg', '.gif', '.webp'))

--- a/uploads/templates/admin/uploads/document/change_form.html
+++ b/uploads/templates/admin/uploads/document/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_urls %}
+{% load admin_urls %}
 
 {% block object-tools-items %}
     {{ block.super }}

--- a/uploads/templates/admin/uploads/document/change_form.html
+++ b/uploads/templates/admin/uploads/document/change_form.html
@@ -1,0 +1,11 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_urls %}
+
+{% block object-tools-items %}
+    {{ block.super }}
+    <li>
+        <a href="https://squoosh.app/" target="_blank">
+            <i class="icon-picture icon-alpha75"></i> Optimiser les images
+        </a>
+    </li>
+{% endblock %}


### PR DESCRIPTION
# Django Uploads

Modifications de l'application Open Source Django Uploads afin d'ajouter des warnings sur le poids des images

## Modifications:
### Documents:
Sur la page des documents, un emoji ⚠ apparait à coté des images ('.png', '.jpg', '.jpeg', '.gif', '.webp') pesant + de 300ko.
Les autres documents (ex: pdf) ne sont pas impactés.
Le poids est modifiable dans les settings.py de briefme_core
Un contrôle et un échappement des noms de fichiers contenant des accents a aussi été ajouté.
Le nom du fichier est aussi disponible sur le lien des différents fichiers.
![Capture d’écran 2025-06-03 à 16 49 26](https://github.com/user-attachments/assets/495a408a-1992-4f6f-a323-274707b3ffbb)

### Document:
Un bandeau d'avertissement apparait seulement sur les images (voir liste au dessus) si elle dépasse les 300ko.
Un lien est aussi disponible à droite pour optimiser les images (non visible sur mon environnement)
![Capture d’écran 2025-06-03 à 16 49 48](https://github.com/user-attachments/assets/37755190-c622-495d-8699-a1533c2aefb6)

## Linked Issue: 
https://github.com/briefmnews/django-uploads/issues/1

## Linked PRs:

- Django Uploads: https://github.com/briefmnews/django-uploads/pull/2
- Briefme Core: https://github.com/briefmnews/briefme-core/pull/393